### PR TITLE
Replace create_function (deprecated in PHP 7.2)

### DIFF
--- a/inc/functions.inc.php
+++ b/inc/functions.inc.php
@@ -24,3 +24,10 @@ function is_page_have_tags() {
 	$taxonomies = get_object_taxonomies( 'page' );
 	return in_array( 'post_tag', $taxonomies );
 }
+
+/**
+ * Register SimpleTags widget
+ */
+function st_register_widget() {
+	register_widget('SimpleTags_Widget');
+}

--- a/simple-tags.php
+++ b/simple-tags.php
@@ -77,7 +77,7 @@ function init_simple_tags() {
 		new SimpleTags_Admin();
 	}
 
-	add_action( 'widgets_init', create_function( '', 'return register_widget("SimpleTags_Widget");' ) );
+	add_action( 'widgets_init', 'st_register_widget' );
 }
 
 add_action( 'plugins_loaded', 'init_simple_tags' );


### PR DESCRIPTION
I've decided to replace create_function with a custom function instead of an anonymous function (introduced in PHP 5.3) because this way it will be compatible with PHP 5.2+.

http://php.net/create_function