### PR TITLE
Related posts do not appear in the RSS feed.

### DIFF
--- a/inc/class.client.related_posts.php
+++ b/inc/class.client.related_posts.php
@@ -9,7 +9,7 @@ class SimpleTags_Client_RelatedPosts {
 	 */
 	public function __construct() {
 		// Add related posts in post ( all / feedonly / blogonly / homeonly / singularonly / singleonly / pageonly /no )
-		if ( ( 'no' !== SimpleTags_Plugin::get_option_value( 'rp_embedded' ) ) || ( 1 === SimpleTags_Plugin::get_option_value( 'rp_feed' ) ) ) {
+		if ( ( 'no' !== SimpleTags_Plugin::get_option_value( 'rp_embedded' ) ) || ( 1 == SimpleTags_Plugin::get_option_value( 'rp_feed' ) ) ) {
 			add_filter( 'the_content', array( __CLASS__, 'the_content' ), 999993 );
 		}
 	}


### PR DESCRIPTION
Hi,

Related posts do not appear in the feed on WordPress 5.2.2 ( Just Installed )

## How to reproduce

-Install Simple Tags
-Features-> Related posts by terms-> "ON"
-Related Posts-> Automatically display related posts into feeds-> "ON"
-Create a post as follows
  -postA with tag1
  -postB with tag1

### Reason
Perhaps this code refactor has changed it to "===".
Since the option contains a string instead of a int, it is false if "===".

https://github.com/BeAPI/simple-tags/blame/3eca3c636ee2b4f35d0fb25cb6688f09ba961f13/inc/class.client.related_posts.php#L12


Thanks